### PR TITLE
publish message パフォーマンス改善

### DIFF
--- a/badge-awarding-service/go-app/usecase/push/publish.go
+++ b/badge-awarding-service/go-app/usecase/push/publish.go
@@ -10,38 +10,43 @@ import (
 )
 
 type PublishMessageUseCase struct {
-	repo notification.MessagePublisher
+	repo   notification.MessagePublisher
+	imgUrl string
 }
 
 func NewPublishMessageUseCase(repo notification.MessagePublisher) *PublishMessageUseCase {
-	return &PublishMessageUseCase{repo: repo}
+	imgUrl, err := management.CreatePublicBadgeImgUrl("bucket", "keyname")
+	if err != nil && imgUrl == nil {
+		panic(err)
+	}
+	return &PublishMessageUseCase{
+		repo:   repo,
+		imgUrl: *imgUrl,
+	}
+}
+
+var stringType = aws.String("String")
+
+func makeStringAttr(val string) types.MessageAttributeValue {
+	return types.MessageAttributeValue{
+		DataType:    stringType,
+		StringValue: aws.String(val),
+	}
 }
 
 // TODO: タイトルを設定できるようにする
 func (uc PublishMessageUseCase) Do(ctx context.Context, messageBody, userName, address, message string) error {
-	imgUrl, err := management.CreatePublicBadgeImgUrl("bucket", "keyname")
-	if err != nil {
-		return err
-	}
 	// sqsに送信するinputを生成
-	sendMessageWithImgUrl, err := notification.GenerateSendMessageWithImgUrl("aa", *imgUrl)
+	sendMessageWithImgUrl, err := notification.GenerateSendMessageWithImgUrl("aa", uc.imgUrl)
 	sendMessage, err := json.Marshal(sendMessageWithImgUrl)
 	if err != nil {
 		return err
 	}
+
 	sqsAttributeValues := map[string]types.MessageAttributeValue{
-		"userName": {
-			DataType:    aws.String("String"),
-			StringValue: aws.String(userName),
-		},
-		"message": {
-			DataType:    aws.String("String"),
-			StringValue: aws.String(message),
-		},
-		"address": {
-			DataType:    aws.String("String"),
-			StringValue: aws.String(address),
-		},
+		"userName": makeStringAttr(userName),
+		"message":  makeStringAttr(message),
+		"address":  makeStringAttr(address),
 	}
 	// sqsにメッセージを送信する
 	err = uc.repo.PublishMailMessage(ctx, string(sendMessage), sqsAttributeValues)


### PR DESCRIPTION
- 改善前と後
    - 🎉 処理時間が `204.2ns` 速くなった
    - 🎉 確保されるメモリの量が `160B` 少なくなった
    - 🎉 メモリ確保回数7回下がった(GC負荷軽減)